### PR TITLE
separate blackMarketGoodStuffRequiresContact from blackMarketRequiresContact

### DIFF
--- a/assets/starpocalypse.json
+++ b/assets/starpocalypse.json
@@ -84,7 +84,8 @@
     # Black Market handling fee (bribe) as a fraction of the Open Market tariff. If tariff is 30%, Black Market bribe will be 15%.
     "blackMarketFenceCut": 0.5,# vanilla: 0
     # Black market access requires a pirate contact at that location.
-    "blackMarketRequiresContact": true, # vanilla: false If Nexerelin is present: No contact will be required if the planet is in rebellion. Restrictions below will still apply though.
+    "blackMarketRequiresContact": true, # vanilla: false If Nexerelin is present: No contact will be required if the planet is in rebellion.
+    "blackMarketGoodStuffRequiresContact": true, # vanilla: false Accessing black market can be done but good stuff is sold by contacts as below.
     # Not every contact can get you the good stuff. At least this importance is required of the blackMarket contact to enable you buying this
     # 0: No Contact required
     # 1: Very Low

--- a/src/starpocalypse/helper/ConfigHelper.java
+++ b/src/starpocalypse/helper/ConfigHelper.java
@@ -59,6 +59,9 @@ public class ConfigHelper {
     private static boolean blackMarketRequiresContact = false;
 
     @Getter
+    private static boolean blackMarketGoodStuffRequiresContact = false;
+
+    @Getter
     private static int blackMarketWeaponT0 = 0;
 
     @Getter
@@ -278,6 +281,7 @@ public class ConfigHelper {
         regulationMaxTier = settings.optInt("regulationMaxLegalTier", 0);
         shyBlackMarket = settings.optBoolean("shyBlackMarket", true);
         blackMarketRequiresContact = settings.optBoolean("blackMarketRequiresContact", true);
+        blackMarketGoodStuffRequiresContact = settings.optBoolean("blackMarketGoodStuffRequiresContact", true);
 
         blackMarketWeaponT0 = settings.optInt("blackMarketWeaponT0", 0);
         blackMarketWeaponT1 = settings.optInt("blackMarketWeaponT1", 0);

--- a/src/starpocalypse/submarket/RegulatedBlackMarket.java
+++ b/src/starpocalypse/submarket/RegulatedBlackMarket.java
@@ -145,7 +145,7 @@ public class RegulatedBlackMarket extends BlackMarketPlugin {
             return false;
         }
 
-        if(ConfigHelper.isBlackMarketRequiresContact())
+        if(ConfigHelper.isBlackMarketGoodStuffRequiresContact())
         {
             return bestContactLevel < getContactLevelFor(stack);
         }
@@ -203,7 +203,7 @@ public class RegulatedBlackMarket extends BlackMarketPlugin {
             return false;
         }
 
-        if(ConfigHelper.isBlackMarketRequiresContact())
+        if(ConfigHelper.isBlackMarketGoodStuffRequiresContact())
         {
             return bestContactLevel < getContactLevelFor(member);
         }
@@ -239,7 +239,7 @@ public class RegulatedBlackMarket extends BlackMarketPlugin {
     public void updateCargoPrePlayerInteraction()
     {
         super.updateCargoPrePlayerInteraction();
-        if(ConfigHelper.isBlackMarketRequiresContact())
+        if(ConfigHelper.isBlackMarketGoodStuffRequiresContact())
         {
             getBestContact();
         }


### PR DESCRIPTION
I wanted to access the basic black market while still needing contact for the good stuff. This extra config option allows that.

Tested with latest starsector and a bunch of mods, no issues. Testable version available here: https://github.com/random-cdda-modder/starpocalypse/releases/download/4.2.0-alpha0/starpocalypse-4.2.0.zip

Separately, you might also be interested in a fixed github release action (and gradle config that does not depend on your local machine): https://github.com/random-cdda-modder/starpocalypse/compare/41b79208bc80ac85ddd55ddcd33a17c0aef4f7ee...450658fb42addcd3119479522e3b1a87dd30cb8b

I did not include those in the PR to avoid any possibility of breaking your local workflow.